### PR TITLE
support selective indexing from OAI based on datestamp

### DIFF
--- a/cdmdexer.gemspec
+++ b/cdmdexer.gemspec
@@ -1,5 +1,6 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'cdmdexer/version'
 
@@ -9,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ['chadfennell']
   spec.email         = ['fenne035@umn.edu']
 
-  spec.summary       = %q{Load CONTENTdm data into a Solr Index. CDMDEXER expects to run inside a Rails application.}
+  spec.summary       = 'Load CONTENTdm data into a Solr Index. CDMDEXER expects to run inside a Rails application.'
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
@@ -17,11 +18,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'hash_at_path', '~> 0.1'
   spec.add_dependency 'contentdm_api', '~> 0.5.0'
+  spec.add_dependency 'hash_at_path', '~> 0.1.6'
+  spec.add_dependency 'rsolr', '~> 2.0'
   spec.add_dependency 'sidekiq', '>= 3.5'
   spec.add_dependency 'titleize', '~> 1.4'
-  spec.add_dependency 'rsolr', '~> 2.0'
   # CDMDEXER expects to run in a rails app, but just to avoid adding
   # another external dependency for XML procssing, we rely on activesupport's
   # Has.to_jsonl feature for testing and to allow this gem to function
@@ -29,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rails', '>= 5.2'
 
   spec.add_development_dependency 'bundler', '~> 1.12'
-  spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'yard', '~> 0.9.0'
 end

--- a/lib/cdmdexer/etl_worker.rb
+++ b/lib/cdmdexer/etl_worker.rb
@@ -38,11 +38,20 @@ module CDMDEXER
       @resumption_token  = config.fetch('resumption_token', nil)
       @batch_size        = config.fetch('batch_size', 5).to_i
       @is_recursive      = config.fetch('is_recursive', true)
+      after_date         = config.fetch('after_date', false)
 
       @oai_request = oai_request_klass.new(
         endpoint_url: oai_endpoint,
         resumption_token: resumption_token,
-        set_spec: config.fetch('set_spec', nil)
+        set_spec: config.fetch('set_spec', nil),
+        # Optionally only select records that have been updated after a
+        # certain date. You may need to manually update a parent record
+        # after updating a child in order to signify to the indexer that
+        # some record in the parent's children has been updated. This indexer
+        # expects to only see parent records in the OAI responses.
+        # The default here is to skip indexing based on date.
+        # Rails example for getting a date: `after_date: 2.weeks.ago`
+        after_date: after_date
       )
 
       run_batch!

--- a/test/etl_worker_test.rb
+++ b/test/etl_worker_test.rb
@@ -28,7 +28,8 @@ module CDMDEXER
                                {
                                 endpoint_url: 'http://example.com1',
                                 resumption_token: nil,
-                                set_spec: nil
+                                set_spec: nil,
+                                after_date: false
                                }
                              ]
       oai_request_klass_object.expect :deletable_ids, ['col134:blarg'], []

--- a/test/oai_request_test.rb
+++ b/test/oai_request_test.rb
@@ -32,7 +32,6 @@ module CDMDEXER
             <identifier>blerg.com:foo/123</identifier>
           </header>
           <header status="deleted">
-            <datestamp>2016-10-27</datestamp>
             <identifier>blerg.com:foo/1234</identifier>
           </header>
           <header>
@@ -223,16 +222,16 @@ module CDMDEXER
       end
     end
 
-    # it 'knows the difference between updatable and deletable records' do
-    #   client.expect :get_response,
-    #                 client_response,
-    #                 [URI('http://example.com?verb=ListIdentifiers&metadataPrefix=oai_dc')]
-    #   client_response.expect :body, header_response_with_status
-    #   request = OaiRequest.new endpoint_url: 'http://example.com',
-    #                            client: client
-    #   request.deletable_ids.must_equal(["foo:1234"])
-    #   request.updatables.must_equal([{"identifier"=>"blerg.com:foo/123", :id=>"foo:123"}, {"identifier"=>"blerg.com:foo/1235", :id=>"foo:1235"}])
-    # end
+    it 'knows the difference between updatable and deletable records' do
+      client.expect :get_response,
+                    client_response,
+                    [URI('http://example.com?verb=ListIdentifiers&metadataPrefix=oai_dc')]
+      client_response.expect :body, header_response_with_status
+      request = OaiRequest.new endpoint_url: 'http://example.com',
+                               client: client
+      request.deletable_ids.must_equal(["foo:1234"])
+      request.updatables.must_equal([{"identifier"=>"blerg.com:foo/123", :id=>"foo:123"}, {"identifier"=>"blerg.com:foo/1235", :id=>"foo:1235"}])
+    end
 
     it 'can harvest only records after a provided date' do
       client.expect :get_response,
@@ -244,7 +243,7 @@ module CDMDEXER
                                after_date: 1.week.ago
 
       request.deletable_ids.must_equal(["foo:1239-today"])
-      request.updatables.must_equal([{"datestamp"=>"2020-10-25", "identifier"=>"blerg.com:foo/122235-today", :id=>"foo:122235-today"}])
+      request.updatables.must_equal([{"datestamp"=> today, "identifier"=>"blerg.com:foo/122235-today", :id=>"foo:122235-today"}])
     end
 
     describe 'when given and empty response' do


### PR DESCRIPTION
### Background

Selective harvesting by date is busted in our CONTENTdm instance - it times out. So, we initially abandoned the idea of harvesting by date. That worked well for a few years, but as the index grew, things slowed down.

Recently, we learned that parent record datestamps in OAI are updated when a child record is updated. This gives us an opportunity to short circuit indexing after the initial OAI identifier-only request, meaning we can harvest by date - e.g. recently updated records.

### Resolution

- This MR introduces a new parameter, `after_date`, to `CDMDEXER::OaiRequest` that filters out records with `datestamps` prior to the given date. Rails clients can pass in somthing like`after_date: 1.week.ago` and run indexing jobs weekly in order to only index content for the previous week.
- Updated `hash_at_path` to a recent version to resolve an issue with code that attempted to do in-place updates to string data which will break with frozen strings
- Some minor code formatting


This has been tested and verified in UMedia QA by Jason. 

